### PR TITLE
DHR-20 Add buyable doors and zombie walls

### DIFF
--- a/Maps/NightOfTheUndead/MAP_NightOfTheUndead.tscn
+++ b/Maps/NightOfTheUndead/MAP_NightOfTheUndead.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://bvd5fk8237gkp"]
+[gd_scene load_steps=32 format=3 uid="uid://bvd5fk8237gkp"]
 
 [ext_resource type="PackedScene" uid="uid://dpfndro2upgsp" path="res://Maps/NightOfTheUndead/Assets/SM_NightOfTheUndead.glb" id="1_you0s"]
 [ext_resource type="PackedScene" uid="uid://k4aky2wyyeb8" path="res://Prefabs/PlayerCharacter/PlayerCharacter.tscn" id="2_y35rs"]
@@ -11,6 +11,8 @@
 [ext_resource type="CompressedTexture3D" uid="uid://d34ub26m3bb5" path="res://Maps/NightOfTheUndead/Assets/TEX_FogMask.png" id="9_bnxql"]
 [ext_resource type="CompressedTexture3D" uid="uid://4k1vtixdhp4c" path="res://Maps/NightOfTheUndead/Assets/TEX_FogMaskInverted.png" id="9_wcsqs"]
 [ext_resource type="Script" path="res://Maps/NightOfTheUndead/Enemies.gd" id="11_h3ply"]
+[ext_resource type="Script" path="res://Prefabs/BuyableDoor/BuyableDoor.gd" id="12_1g40e"]
+[ext_resource type="Script" path="res://Components/InteractableComponent.gd" id="12_qf50b"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ykafg"]
 sky_top_color = Color(0.0862745, 0.0980392, 0.172549, 1)
@@ -57,6 +59,33 @@ emission = Color(0.141176, 0.168627, 0.168627, 1)
 height_falloff = 1e-05
 edge_fade = 7.35164
 density_texture = ExtResource("9_wcsqs")
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ixpre"]
+albedo_color = Color(0.458824, 0.27451, 0, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_lrdbu"]
+material = SubResource("StandardMaterial3D_ixpre")
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_bi3c8"]
+size = Vector3(6.40466, 4.3186, 0.215485)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_iff8q"]
+size = Vector3(3.94752, 4.83563, 0.24707)
+
+[sub_resource type="BoxMesh" id="BoxMesh_r2d1j"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_b015q"]
+transparency = 1
+albedo_color = Color(1, 0, 0, 0.313726)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_3qj0n"]
+size = Vector3(6.2014, 4.67261, 0.183868)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_1atdv"]
+size = Vector3(4.14478, 4.80972, 0.185974)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_n3t03"]
+size = Vector3(29.0608, 5.32239, 0.243652)
 
 [node name="MAP_NightOfTheUndead" type="Node3D"]
 
@@ -149,6 +178,186 @@ wait_time = 2.0
 
 [node name="RoundCooldownTimer" type="Timer" parent="."]
 wait_time = 3.0
+
+[node name="BuyableDoor" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.8054, -0.28187, 16.3086)
+script = ExtResource("12_1g40e")
+
+[node name="InteractableComponent" type="Node" parent="BuyableDoor"]
+script = ExtResource("12_qf50b")
+text = "Open door ($PRICE)"
+price = 3000
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="BuyableDoor"]
+transform = Transform3D(6.28983, 0, 0, 0, 4.94303, 0, 0, 0, 0.194612, 0.257003, 2.35644, 0)
+mesh = SubResource("BoxMesh_lrdbu")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="BuyableDoor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.347059, 2.51327, -0.00331116)
+shape = SubResource("BoxShape3D_bi3c8")
+
+[node name="BuyableDoor2" type="StaticBody3D" parent="."]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -24.735, -0.28187, 2.60964)
+script = ExtResource("12_1g40e")
+
+[node name="InteractableComponent" type="Node" parent="BuyableDoor2"]
+script = ExtResource("12_qf50b")
+text = "Open door ($PRICE)"
+price = 1250
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="BuyableDoor2"]
+transform = Transform3D(4.28979, 0, 0, 0, 4.94303, 0, 1.42109e-14, 0, 0.194612, -0.43087, 2.35644, 0)
+mesh = SubResource("BoxMesh_lrdbu")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="BuyableDoor2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.454676, 2.4465, 0.0112305)
+shape = SubResource("BoxShape3D_iff8q")
+
+[node name="BuyableDoor3" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.4055, -0.28187, -16.1382)
+script = ExtResource("12_1g40e")
+
+[node name="InteractableComponent" type="Node" parent="BuyableDoor3"]
+script = ExtResource("12_qf50b")
+text = "Open door ($PRICE)"
+price = 1250
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="BuyableDoor3"]
+transform = Transform3D(3.9326, 0, 0, 0, 4.94303, 0, 0, 0, 0.194612, -0.396149, 2.35644, 0)
+mesh = SubResource("BoxMesh_lrdbu")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="BuyableDoor3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.392267, 2.4465, 0.0112305)
+shape = SubResource("BoxShape3D_iff8q")
+
+[node name="BuyableDoor4" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -35.7111, -0.28187, -16.1545)
+script = ExtResource("12_1g40e")
+
+[node name="InteractableComponent" type="Node" parent="BuyableDoor4"]
+script = ExtResource("12_qf50b")
+text = "Open door ($PRICE)"
+price = 1250
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="BuyableDoor4"]
+transform = Transform3D(4.18232, 0, 0, 0, 4.94303, 0, 0, 0, 0.194612, -0.148785, 2.35644, 0)
+mesh = SubResource("BoxMesh_lrdbu")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="BuyableDoor4"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.144901, 2.4465, 0.0112305)
+shape = SubResource("BoxShape3D_iff8q")
+
+[node name="ZombieDoor" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20.525, -0.283705, 16.3749)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor"]
+transform = Transform3D(6.61531, 0, 0, 0, 4.94449, 0, 0, 0, 0.137277, -2.73435, 2.33126, -0.0699711)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.70752, 2.45954, -0.0735779)
+shape = SubResource("BoxShape3D_3qj0n")
+
+[node name="ZombieDoor2" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.720968, -0.283705, -16.1042)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor2"]
+transform = Transform3D(6.61531, 0, 0, 0, 4.94449, 0, 0, 0, 0.137277, -2.73435, 2.33126, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.70752, 2.45954, -0.0273247)
+shape = SubResource("BoxShape3D_3qj0n")
+
+[node name="ZombieDoor3" type="StaticBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -39.3615, -0.283705, -48.9088)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor3"]
+transform = Transform3D(4.12449, 0, 0, 0, 4.94449, 0, 0, 0, 0.137277, -2.55828, 2.33126, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor3"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.249, 2.43329, -0.0149193)
+shape = SubResource("BoxShape3D_3qj0n")
+
+[node name="ZombieDoor4" type="StaticBody3D" parent="."]
+transform = Transform3D(0.953375, 0, 0.301788, 0, 1, 0, -0.301788, 0, 0.953375, -30.7353, -0.283705, 20.6029)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor4"]
+transform = Transform3D(3.98968, 0, 0, 0, 4.94449, 0, 5.96046e-07, 0, 0.137277, -1.48031, 2.33126, -5.72205e-06)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor4"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.51098, 2.45954, -0.0273237)
+shape = SubResource("BoxShape3D_1atdv")
+
+[node name="ZombieDoor5" type="StaticBody3D" parent="."]
+transform = Transform3D(-0.452513, 0, -0.891758, 0, 1, 0, 0.891758, 0, -0.452513, -55.5299, -0.283705, -7.0797)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor5"]
+transform = Transform3D(4.11593, 0, 0, 0, 4.94449, 0, 5.96046e-07, 0, 0.137277, -1.57966, 2.33126, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor5"]
+transform = Transform3D(0.999998, 0, 8.9407e-08, 0, 1, 0, -8.9407e-08, 0, 0.999998, -1.57238, 2.45954, -0.0273247)
+shape = SubResource("BoxShape3D_1atdv")
+
+[node name="ZombieDoor6" type="StaticBody3D" parent="."]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -48.0193, -0.283705, -45.2639)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor6"]
+transform = Transform3D(4.12449, 0, 0, 0, 4.94449, 0, 0, 0, 0.137277, -2.55828, 2.33126, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor6"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.249, 2.43329, -0.0149193)
+shape = SubResource("BoxShape3D_3qj0n")
+
+[node name="ZombieDoor7" type="StaticBody3D" parent="."]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -15.5893, -0.283705, -35.0343)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor7"]
+transform = Transform3D(4.12449, 0, 0, 0, 4.94449, 0, 0, 0, 0.137277, -2.55828, 2.33126, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor7"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.249, 2.43329, -0.0149193)
+shape = SubResource("BoxShape3D_3qj0n")
+
+[node name="ZombieDoor8" type="StaticBody3D" parent="."]
+transform = Transform3D(0.953375, 0, 0.301788, 0, 1, 0, -0.301788, 0, 0.953375, -2.26088, -0.283705, 25.0219)
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="ZombieDoor8"]
+transform = Transform3D(26.5651, 0, 0.0482862, 0, 4.94449, 0, -9.98199, 0, 0.128504, -13.8846, 2.33126, 6.48846)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ZombieDoor8"]
+transform = Transform3D(0.935098, 0, 0.354389, 0, 1, 0, -0.354389, 0, 0.935098, -13.9198, 2.16712, 6.46519)
+shape = SubResource("BoxShape3D_n3t03")
 
 [connection signal="child_order_changed" from="Enemies" to="Enemies" method="_on_child_order_changed"]
 [connection signal="round_cooldown" from="Enemies" to="UI_DevelopmentHud" method="_on_enemies_round_cooldown"]

--- a/Prefabs/BuyableDoor/BuyableDoor.tscn
+++ b/Prefabs/BuyableDoor/BuyableDoor.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://df52hkfojajhn"]
+[gd_scene load_steps=6 format=3 uid="uid://df52hkfojajhn"]
 
 [ext_resource type="Script" path="res://Components/InteractableComponent.gd" id="1_24ejg"]
+[ext_resource type="Script" path="res://Prefabs/BuyableDoor/BuyableDoor.gd" id="1_ewwl8"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ixpre"]
 albedo_color = Color(0.458824, 0.27451, 0, 1)
@@ -12,6 +13,7 @@ material = SubResource("StandardMaterial3D_ixpre")
 size = Vector3(3.11321, 4.2533, 0.24707)
 
 [node name="BuyableDoor" type="StaticBody3D"]
+script = ExtResource("1_ewwl8")
 
 [node name="InteractableComponent" type="Node" parent="."]
 script = ExtResource("1_24ejg")

--- a/Prefabs/PlayerCharacter/PlayerCharacter.tscn
+++ b/Prefabs/PlayerCharacter/PlayerCharacter.tscn
@@ -340,6 +340,8 @@ bind/20/bone = -1
 bind/20/pose = Transform3D(-6.66667, 0, 8.95392e-06, -1.49666e-12, -6.66666, 1.58635e-06, 8.95392e-06, 0, 6.66666, 1.28751e-06, 1.94618, 1.0229)
 
 [node name="PlayerCharacter" type="CharacterBody3D"]
+collision_layer = 3
+collision_mask = 3
 script = ExtResource("1_p62v6")
 
 [node name="HealthComponent" type="Node" parent="."]
@@ -545,7 +547,7 @@ skin = SubResource("Skin_kl7bx")
 transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0, 0)
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="."]
-transform = Transform3D(-1.1384e-07, 0.00152281, 0.149992, -1.08931e-09, -0.149992, 0.00152281, 0.15, 6.65046e-11, 1.13845e-07, -0.579465, 1.84594, -2.53292e-08)
+transform = Transform3D(-1.1384e-07, 0.00152248, 0.149992, -1.08883e-09, -0.149992, 0.00152248, 0.15, 6.66768e-11, 1.13845e-07, -0.579467, 1.84594, -2.5328e-08)
 bone_name = "Hand_R"
 bone_idx = 8
 use_external_skeleton = true

--- a/Prefabs/ZombieWall/ZombieDoor.tscn
+++ b/Prefabs/ZombieWall/ZombieDoor.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=3 uid="uid://cp64pjwumo2ay"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_r2d1j"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_b015q"]
+transparency = 1
+albedo_color = Color(1, 0, 0, 0.313726)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_1atdv"]
+size = Vector3(4.14478, 4.80972, 0.185974)
+
+[node name="ZombieDoor" type="StaticBody3D"]
+collision_layer = 2
+collision_mask = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 3.52421, 0, 0, 0, 0.137277, 0, 1.86325, 0)
+mesh = SubResource("BoxMesh_r2d1j")
+surface_material_override/0 = SubResource("StandardMaterial3D_b015q")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8362, -0.0735779)
+shape = SubResource("BoxShape3D_1atdv")


### PR DESCRIPTION
Adds buyable doors and walls that only zombies can pass through, these will be used to let the zombies spawn outside of the playable area, but still allow them to walk into it while preventing the player from leaving.
